### PR TITLE
Add an `execute` method that calls `add` and blocks if rate limit is exceeded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,9 @@
 # CHANGELOG
 
 # v1.1.0
- * Simplify `initialize` method to hide bucket configs in an `options` map - [@mathu97](https://github.com/mathu97).
- * Add `execute` method that calls `add` and blocks if rate limit is exceeded before running user's code block - [@mathu97](https://github.com/mathu97).
- * Add `DummyAPI` class for testing purposes, that can be used to simulate a rate limited API - [@mathu97](https://github.com/mathu97). 
+ * [#5](https://github.com/koffeefinance/ratelimitcop/pull/5) Simplify `initialize` method to hide bucket configs in an `options` map - [@mathu97](https://github.com/mathu97).
+ * [#5](https://github.com/koffeefinance/ratelimitcop/pull/5) Add `execute` method that calls `add` and blocks if rate limit is exceeded before running user's code block - [@mathu97](https://github.com/mathu97).
+ * [#5](https://github.com/koffeefinance/ratelimitcop/pull/5) Add `DummyAPI` class for testing purposes, that can be used to simulate a rate limited API - [@mathu97](https://github.com/mathu97). 
 
 # v1.0.1
  * Renaming of classes to match gem name - [@mathu97](https://github.com/mathu97).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+# v1.1.0
+ * Simplify `initialize` method to hide bucket configs in an `options` map - [@mathu97](https://github.com/mathu97).
+ * Add `execute` method that calls `add` and blocks if rate limit is exceeded before running user's code block - [@mathu97](https://github.com/mathu97).
+ * Add `DummyAPI` class for testing purposes, that can be used to simulate a rate limited API - [@mathu97](https://github.com/mathu97). 
+
 # v1.0.1
  * Renaming of classes to match gem name - [@mathu97](https://github.com/mathu97).
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    ratelimitcop (1.0.1)
+    ratelimitcop (1.1.0)
       redis (~> 4.4)
       redis-namespace (~> 1.8.1)
 

--- a/README.md
+++ b/README.md
@@ -24,9 +24,9 @@ Or install it yourself as:
 
 ### Basic Usage
 
-To rate limit calling a block of code, simply initialize `Ratelimitcop` with a `threshold` and `interval`, then pass the block of code into the `execute` method. `threshold` is the maximum number of requests that can be made within a timed `interval`, where `interval` is in seconds. `execute` will automatically block if the execution of your code block will exceed the given rate limit.
+To rate limit calling a block of code, simply initialize `Ratelimitcop` with a `threshold` and `interval`, then pass the block of code to the `execute` method. `threshold` is the maximum number of requests that can be made within a timed `interval`, where `interval` is in seconds. `execute` will automatically block if the execution of your code block will exceed the given rate limit.
 
-Note: You need let Ratelimitcop know how it can connect to your Redis instance (or else it will default to `localhost`, port 6379, as per the [Redis gem docs](https://www.rubydoc.info/gems/redis#getting-started)). To do this pass your Redis connection config as a parameter when intializing Ratelimitcop. View the [Redis gem docs](https://www.rubydoc.info/gems/redis#getting-started) to see the different ways you can connect Ratelimitcop to your Redis instance.
+Note: You need let Ratelimitcop know how it can connect to your Redis instance (or it will default to `localhost`, port 6379, as per the [Redis gem docs](https://www.rubydoc.info/gems/redis#getting-started)). To do this pass your Redis connection config as a parameter when intializing Ratelimitcop. View the [Redis gem docs](https://www.rubydoc.info/gems/redis#getting-started) to see the different ways you can connect Ratelimitcop to your Redis instance.
 
 Here is an example of an API client that uses Ratelimitcop to ensure the API's rate limits are not exceeded.
 
@@ -50,7 +50,7 @@ Here is an example of an API client that uses Ratelimitcop to ensure the API's r
     end
 
     def quote(ticker:)
-      # regardless of how this method is called it will block if rate limit is exceeded before trying to run the code block
+      # regardless of how this method is called it will block if the rate limit is exceeded before trying to run the code block
       @limiter.execute do
         res = @client.quote(URI.encode(ticker))
         res

--- a/lib/errors.rb
+++ b/lib/errors.rb
@@ -1,0 +1,1 @@
+class InvalidBucketConfigError < StandardError; end

--- a/lib/ratelimitcop/version.rb
+++ b/lib/ratelimitcop/version.rb
@@ -1,3 +1,3 @@
 class Ratelimitcop
-  VERSION = '1.0.1'.freeze
+  VERSION = '1.1.0'.freeze
 end

--- a/test/dummy_api.rb
+++ b/test/dummy_api.rb
@@ -1,0 +1,26 @@
+# a dummy API to help test ratelimitcop
+class DummyAPI
+  # default rate limit set to 10 reqs/second
+  def initialize(rate_limit_threshold: 10, rate_limit_interval: 1)
+    @count = 0
+    @threshold = rate_limit_threshold
+    @interval = rate_limit_interval
+  end
+
+  def request
+    @current_time = Time.now.to_i
+    @start ||= @current_time
+    @end ||= @start + @interval
+
+    @count += 1
+
+    raise TooManyRequestsError if @count > @threshold && @current_time < @end
+    return unless @current_time > @end
+
+    @start = @current_time
+    @end = @start + @interval
+    @count = 0
+  end
+end
+
+class TooManyRequestsError < StandardError; end

--- a/test/dummy_api_test.rb
+++ b/test/dummy_api_test.rb
@@ -1,0 +1,37 @@
+require 'test_helper'
+
+class DummyAPITest < Minitest::Test
+  def setup
+    @dummy_api = DummyAPI.new(
+      rate_limit_threshold: 10,
+      rate_limit_interval: 1
+    )
+  end
+
+  def after
+    Timecop.return
+  end
+
+  def test_dummy_api_actually_rate_limits
+    assert_raises TooManyRequestsError do
+      11.times { @dummy_api.request }
+    end
+  end
+
+  def test_dummy_api_does_not_raise_error_if_request_called_according_to_limts
+    request_count = 0
+    10.times do
+      @dummy_api.request
+      request_count += 1
+    end
+
+    Timecop.travel(1)
+
+    10.times do
+      @dummy_api.request
+      request_count += 1
+    end
+
+    assert_equal 20, request_count
+  end
+end

--- a/test/ratelimitcop_test.rb
+++ b/test/ratelimitcop_test.rb
@@ -6,8 +6,7 @@ class RatelimitcopTest < Minitest::Test
     @limiter = Ratelimitcop.new(
       name: 'test',
       threshold: 10,
-      interval: 5,
-      time_span: 600
+      interval: 5
     )
 
     # will connect to the fakeredis that the limiter is connected to
@@ -15,17 +14,63 @@ class RatelimitcopTest < Minitest::Test
     @redis.flushdb
   end
 
+  def after
+    Timecop.return
+  end
+
   def test_that_it_has_a_version_number
     refute_nil ::Ratelimitcop::VERSION
   end
 
-  def test_argument_error_raised_if_interval_greater_than_time_span
-    assert_raises ArgumentError do
+  def test_bucket_interval_option_is_set
+    limiter = Ratelimitcop.new(
+      name: 'test',
+      threshold: 10,
+      interval: 5,
+      options: {
+        bucket_interval: 6
+      }
+    )
+
+    assert_equal 6, limiter.instance_variable_get(:@bucket_interval)
+  end
+
+  def test_bucket_time_span_option_is_set
+    limiter = Ratelimitcop.new(
+      name: 'test',
+      threshold: 10,
+      interval: 5,
+      options: {
+        bucket_time_span: 700
+      }
+    )
+
+    assert_equal 700, limiter.instance_variable_get(:@bucket_time_span)
+  end
+
+  def test_bucket_span_option_is_set
+    limiter = Ratelimitcop.new(
+      name: 'test',
+      threshold: 10,
+      interval: 5,
+      options: {
+        bucket_span: 4
+      }
+    )
+
+    assert_equal 4, limiter.instance_variable_get(:@bucket_span)
+  end
+
+  def test_invalid_bucket_config_error_raised_if_bucket_interval_greater_than_bucket_time_span
+    assert_raises InvalidBucketConfigError do
       Ratelimitcop.new(
         name: 'test',
         threshold: 10,
         interval: 800,
-        time_span: 600
+        options: {
+          bucket_interval: 800,
+          bucket_time_span: 600
+        }
       )
     end
   end
@@ -70,9 +115,7 @@ class RatelimitcopTest < Minitest::Test
     limiter = Ratelimitcop.new(
       name: 'test',
       threshold: 10,
-      interval: 4,
-      bucket_span: 4,
-      time_span: 600
+      interval: 4
     )
 
     count = 0
@@ -112,6 +155,30 @@ class RatelimitcopTest < Minitest::Test
     stub_time
 
     assert_equal 22, @limiter.send(:bucket_index)
+  end
+
+  def test_exec_handles_dummy_api_rate_limit
+    limiter = Ratelimitcop.new(
+      name: 'test_exec_handles_dummy_api_rate_limit',
+      threshold: 10,
+      interval: 2
+    )
+
+    dummy_api = DummyAPI.new(
+      rate_limit_threshold: 10,
+      rate_limit_interval: 2
+    )
+
+    count = 0
+
+    15.times do
+      limiter.execute do
+        dummy_api.request
+        count += 1
+      end
+    end
+
+    assert_equal 15, count
   end
 
   def stub_time

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,5 +1,6 @@
 $LOAD_PATH.unshift File.expand_path('../lib', __dir__)
 require 'ratelimitcop'
+require 'dummy_api'
 
 require 'minitest/autorun'
 require 'mocha/minitest'


### PR DESCRIPTION
Contains breaking changes:
 * Simplifies the `initialize` method such that bucket configs, things that an average user will not care much about, are hidden in an `options` map.
 * Added an `execute` method that increments the request count and blocks if the request will exceed the rate limit.
 * Added a `DummyAPI` class for testing purposes, that can be used to simulate an API that has rate limits.
 